### PR TITLE
Improve English design and stimuli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore generated data files
+vignettes.csv
+participant_csvs/
+
+# Common R user files
+.Rhistory
+.RData

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-# Bayesian Morality Experiment in R
+# Bayesian Morality Experiment
 
-Este repositorio contiene:
-1. `generate_vignettes.R`: genera `vignettes.csv` con 200 viñetas.
-2. `create_participant_csvs.R`: genera 200 archivos `participant_001.csv` … `participant_200.csv`.
-3. (Opcional) `clean_and_analyze.R`: limpia y analiza los datos recopilados.
+This repository contains R scripts to create randomized vignettes for an online moral judgment study. All materials are in English so they can be easily used with Prolific or other recruitment platforms.
 
+Before generating any files, make sure the required R packages are installed. The `setup.sh` script installs `r-base-core` and the needed CRAN libraries using `apt-get --no-install-recommends`, so no direct CRAN access is required. You can optionally set `http_proxy` and `https_proxy` if your network uses a proxy.
+
+## Files
+1. `generate_vignettes.R` – creates `vignettes.csv` with 400 vignettes (100 per experimental cell).
+2. `create_participant_csvs.R` – produces 200 CSV files `participant_001.csv` … `participant_200.csv`, each containing 12 vignettes in random order.
+
+## Usage
+After running `./setup.sh` once, generate the materials by running the following R scripts in order:
+
+```R
+source("generate_vignettes.R")      # creates vignettes.csv
+source("create_participant_csvs.R")  # creates files in participant_csvs/
+```
+
+When recruiting on Prolific, give each worker the CSV matching their numeric ID. For example, participant 17 should receive `participant_017.csv`. Upload the files to your survey platform so Prolific can redirect each worker to the correct vignette set.
+
+Each participant CSV can be uploaded to your survey software (e.g., Qualtrics or jsPsych) and linked to Prolific using their unique participant ID. Make sure to randomize presentation order if your platform allows.

--- a/create_participant_csvs.R
+++ b/create_participant_csvs.R
@@ -1,8 +1,7 @@
 library(dplyr)
 library(readr)
-library(purrr)
 
-# Read vignettes.csv 
+# Read vignettes.csv
 vigs <- read_csv("vignettes.csv", show_col_types = FALSE)
 
 # Create output directory if it doesn't exist
@@ -17,23 +16,22 @@ for (pid in seq_len(200)) {
 
   ilow <- vigs %>%
     filter(Framework == "intentionalist", Ambiguity == "low") %>%
-    slice_sample(n = 2)
+    slice_sample(n = 3)
 
   ihigh <- vigs %>%
     filter(Framework == "intentionalist", Ambiguity == "high") %>%
-    slice_sample(n = 2)
+    slice_sample(n = 3)
 
   clow <- vigs %>%
     filter(Framework == "consequentialist", Ambiguity == "low") %>%
-    slice_sample(n = 2)
+    slice_sample(n = 3)
 
   chigh <- vigs %>%
     filter(Framework == "consequentialist", Ambiguity == "high") %>%
-    slice_sample(n = 2)
+    slice_sample(n = 3)
 
   out <- bind_rows(ilow, ihigh, clow, chigh) %>%
-  slice_sample(n = nrow(.))
-
+    slice_sample(n = nrow(.))
 
   file_name <- file.path(out_dir, sprintf("participant_%03d.csv", pid))
   write_csv(out, file_name)

--- a/generate_vignettes.R
+++ b/generate_vignettes.R
@@ -1,25 +1,25 @@
 library(dplyr)
 library(stringr)
 library(readr)
-library(purrr)
 library(tibble)
 
-# Template texts for the vignettes
+# Template texts for the vignettes (all English)
 templates <- list(
-  intentionalist_low = "Agent {Agent} deliberately performed an action knowing there was a {Prob} chance that exactly {Damage} innocent individuals would be harmed. {Agent}’s primary motivation was {Motivation}, and {Agent} was certain of the outcome.",
-  intentionalist_high = "Agent {Agent} took an action under uncertain conditions: there was a {ProbRange} chance that between {DamageRange} innocents might suffer harm. Although {Agent} intended {Motivation}, their knowledge was not fully clear.",
-  consequentialist_low = "Agent {Agent} made a decision that would result in exactly {Damage} victims with probability {Prob}. The focus is on the outcome; nothing is known about {Agent}’s intentions.",
-  consequentialist_high = "Agent {Agent} chose a course of action with an uncertain outcome: there was a {ProbRange} chance of harming between {DamageRange} individuals. {Agent}’s mental states remain opaque; emphasis is solely on expected harm."
+  intentionalist_low = "In {Setting}, {Agent} knowingly performed an action with a {Prob} chance that exactly {Damage} innocent people would be harmed. {Agent}'s main reason was {Motivation}, and they were fully aware of the outcome.",
+  intentionalist_high = "In {Setting}, {Agent} acted under uncertainty, facing a {ProbRange} chance that between {DamageRange} innocents could be harmed. {Agent} intended {Motivation} but did not know the exact consequences.",
+  consequentialist_low = "In {Setting}, {Agent}'s decision guaranteed exactly {Damage} victims with probability {Prob}. The moral evaluation considers only the outcome, not {Agent}'s intentions.",
+  consequentialist_high = "In {Setting}, {Agent} chose a risky path with a {ProbRange} chance that between {DamageRange} people would be harmed. The emphasis is on expected harm; {Agent}'s thoughts remain unknown."
 )
 
 # Elements for random generation
-Agents <- c("Alex", "Taylor", "Jordan", "Morgan", "Casey", "Riley", "Quinn", "Avery")
-Motivations <- c("to prevent a greater harm", "to obey orders", "to protect a loved one")
-Prob_low <- c(0.6, 0.8, 0.95)
-Prob_high_ranges <- list(c(0.4, 0.6), c(0.6, 0.8))
-Damage_low <- c(1, 3, 5)
-Damage_high_ranges <- list(c(1, 3), c(3, 7))
-num_per_cell <- 50
+Agents <- c("Alex", "Taylor", "Jordan", "Morgan", "Casey", "Riley", "Quinn", "Avery", "Jamie", "Chris", "Pat")
+Motivations <- c("to prevent a greater harm", "to obey orders", "to protect a loved one", "to follow company policy", "to save resources")
+Settings <- c("during a medical emergency", "on a spaceship", "in a military mission", "at an AI control center")
+Prob_low <- c(0.5, 0.7, 0.9)
+Prob_high_ranges <- list(c(0.2, 0.5), c(0.5, 0.9))
+Damage_low <- c(1, 2, 4, 6)
+Damage_high_ranges <- list(c(2, 5), c(5, 9))
+num_per_cell <- 100
 
 # Format probability as a percentage string
 format_pct <- function(p) {
@@ -30,6 +30,7 @@ format_pct <- function(p) {
 generate_row <- function(framework, ambiguity, idx) {
   agent <- sample(Agents, 1)
   motivation <- sample(Motivations, 1)
+  setting <- sample(Settings, 1)
   template <- templates[[str_c(framework, "_", ambiguity)]]
 
   if (ambiguity == "low") {
@@ -39,12 +40,14 @@ generate_row <- function(framework, ambiguity, idx) {
       str_replace_all("\\{Agent\\}", agent) %>%
       str_replace_all("\\{Prob\\}", format_pct(prob_val)) %>%
       str_replace_all("\\{Damage\\}", as.character(damage_val)) %>%
-      str_replace_all("\\{Motivation\\}", motivation)
+      str_replace_all("\\{Motivation\\}", motivation) %>%
+      str_replace_all("\\{Setting\\}", setting)
     tibble(
       ID = idx,
       Framework = framework,
       Ambiguity = ambiguity,
       Agent = agent,
+      Setting = setting,
       Prob = format_pct(prob_val),
       ProbRange = NA_character_,
       Damage = damage_val,
@@ -61,12 +64,14 @@ generate_row <- function(framework, ambiguity, idx) {
       str_replace_all("\\{Agent\\}", agent) %>%
       str_replace_all("\\{ProbRange\\}", prob_range_str) %>%
       str_replace_all("\\{DamageRange\\}", damage_range_str) %>%
-      str_replace_all("\\{Motivation\\}", motivation)
+      str_replace_all("\\{Motivation\\}", motivation) %>%
+      str_replace_all("\\{Setting\\}", setting)
     tibble(
       ID = idx,
       Framework = framework,
       Ambiguity = ambiguity,
       Agent = agent,
+      Setting = setting,
       Prob = NA_character_,
       ProbRange = prob_range_str,
       Damage = NA_real_,

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Install R package dependencies for the experiment
+
+set -e
+
+# Optionally configure an HTTP(S) proxy by setting environment variables
+# e.g. export http_proxy=http://proxy.example.com:3128
+# e.g. export https_proxy=$http_proxy
+
+# Update package lists
+sudo apt-get update
+
+# Install minimal R base and required packages from Ubuntu repositories
+sudo apt-get install -y --no-install-recommends \
+  r-base-core r-cran-dplyr r-cran-readr r-cran-stringr r-cran-tibble
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add `setup.sh` script to install R dependencies via apt-get or CRAN
- note the setup step in README
- clean up dependencies and add `.gitignore`
- streamline setup and clarify Prolific instructions

## Testing
- `bash setup.sh`
- `Rscript generate_vignettes.R`
- `Rscript create_participant_csvs.R`


------
https://chatgpt.com/codex/tasks/task_e_684d4d4c1b88832aa4c93713ae7546b4