### PR TITLE
Add GitHub Pages documentation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v1

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+# Bayesian Morality Study
+
+This site provides instructions for generating the materials used in the experiment and links to the resulting CSV files.
+
+## Prerequisites
+
+* R version 4.0 or later
+* The packages listed at the top of the scripts (dplyr, stringr, readr, purrr, tibble)
+
+## Generating the Vignettes
+
+Run the following command from the repository root:
+
+```R
+source("generate_vignettes.R")
+```
+
+This creates `vignettes.csv`, which contains all 200 vignettes used in the study.
+
+## Creating Participant CSVs
+
+After `vignettes.csv` has been generated, run:
+
+```R
+source("create_participant_csvs.R")
+```
+
+This script creates a `participant_csvs/` directory containing 200 files named `participant_001.csv` through `participant_200.csv`.
+
+## Data Files
+
+Once the above scripts have been executed, the following data files will be available:
+
+- [`vignettes.csv`](../vignettes.csv)
+- [participant CSVs](../participant_csvs/)
+
+You can download these files directly or use them for further analysis.


### PR DESCRIPTION
## Summary
- add documentation site under `docs/`
- upload GitHub Pages workflow so `docs/` is served as a website

## Testing
- `Rscript generate_vignettes.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d8178358832a930498e2310c4614